### PR TITLE
SysEleven specific fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
  */
 
 project.ext {
-    midonetVersion = "5.2.1-hf3"
+    midonetVersion = "5.2.1-hf3-se1"
     vendor = 'MidoNet'
     maintainer = "MidoNet user list <midonet-user@midonet.org>"
     url = "http://midonet.org"

--- a/midonet-cluster/src/main/scala/org/midonet/cluster/services/c3po/C3POMinion.scala
+++ b/midonet-cluster/src/main/scala/org/midonet/cluster/services/c3po/C3POMinion.scala
@@ -224,7 +224,7 @@ object C3POMinion {
              classOf[NeutronNetwork] ->
                 new NetworkTranslator(storage, pathBldr),
              classOf[NeutronRouter] ->
-                new RouterTranslator(storage, stateTableStorage, pathBldr),
+                new RouterTranslator(storage, stateTableStorage, pathBldr, config),
              classOf[NeutronRouterInterface] ->
                 new RouterInterfaceTranslator(storage, seqDispenser, config),
              classOf[NeutronSubnet] -> new SubnetTranslator(storage),

--- a/midonet-cluster/src/main/scala/org/midonet/cluster/services/c3po/translators/RouterTranslator.scala
+++ b/midonet-cluster/src/main/scala/org/midonet/cluster/services/c3po/translators/RouterTranslator.scala
@@ -18,6 +18,7 @@ package org.midonet.cluster.services.c3po.translators
 
 import scala.collection.JavaConverters._
 
+import org.midonet.cluster.ClusterConfig
 import org.midonet.cluster.data.storage.{ReadOnlyStorage, StateTableStorage}
 import org.midonet.cluster.models.Commons.Condition.FragmentPolicy
 import org.midonet.cluster.models.Commons.{Condition, IPAddress, IPVersion, UUID}
@@ -34,7 +35,8 @@ import org.midonet.util.concurrent.toFutureOps
 
 class RouterTranslator(protected val storage: ReadOnlyStorage,
                        protected val stateTableStorage: StateTableStorage,
-                       protected val pathBldr: PathBuilder)
+                       protected val pathBldr: PathBuilder,
+                       config: ClusterConfig)
     extends Translator[NeutronRouter]
             with ChainManager with PortManager with RouteManager with RuleManager
             with StateTableManager {
@@ -281,7 +283,10 @@ class RouterTranslator(protected val storage: ReadOnlyStorage,
         List(outRuleBuilder(outSnatRuleId(nr.getId))
                  .setType(Rule.Type.NAT_RULE)
                  .setAction(Action.ACCEPT)
-                 .setNatRuleData(natRuleData(gwIpAddr, dnat = false))
+                 .setNatRuleData(natRuleData(gwIpAddr, dnat = false,
+                                             dynamic = true,
+                                             config.translators.dynamicNatPortStart,
+                                             config.translators.dynamicNatPortEnd))
                  .setCondition(outRuleConditionBuilder),
              outRuleBuilder(outDropUnmatchedFragmentsRuleId(nr.getId))
                  .setType(Rule.Type.LITERAL_RULE)

--- a/midonet-cluster/src/main/scala/org/midonet/cluster/services/c3po/translators/RuleManager.scala
+++ b/midonet-cluster/src/main/scala/org/midonet/cluster/services/c3po/translators/RuleManager.scala
@@ -84,12 +84,12 @@ trait RuleManager {
         Condition.newBuilder.setFragmentPolicy(FragmentPolicy.ANY)
 
     protected def natRuleData(addr: IPAddress, dnat: Boolean,
-                              dynamic: Boolean = true,
-                              port_start: Int = ClusterConfig.MIN_DYNAMIC_NAT_PORT,
-                              port_end: Int = ClusterConfig.MAX_DYNAMIC_NAT_PORT)
+                              dynamic: Boolean,
+                              portStart: Int = ClusterConfig.MIN_DYNAMIC_NAT_PORT,
+                              portEnd: Int = ClusterConfig.MAX_DYNAMIC_NAT_PORT)
     : NatRuleData = {
         if (dynamic)
-            natRuleData(addr, dnat, port_start, port_end)
+            natRuleData(addr, dnat, portStart, portEnd)
         else
             natRuleData(addr, dnat, 0, 0)
     }

--- a/midonet-cluster/src/test/scala/org/midonet/cluster/services/c3po/translators/RouterTranslatorIT.scala
+++ b/midonet-cluster/src/test/scala/org/midonet/cluster/services/c3po/translators/RouterTranslatorIT.scala
@@ -548,7 +548,7 @@ class RouterTranslatorIT extends C3POMinionTestBase {
 
         if (addr != null) {
             data.getNatTargetsCount shouldBe 1
-            data.getNatTargets(0).getTpStart shouldBe 1
+            data.getNatTargets(0).getTpStart shouldBe 1024
             data.getNatTargets(0).getTpEnd shouldBe 0xffff
             data.getNatTargets(0).getNwStart.getAddress shouldBe addr
             data.getNatTargets(0).getNwEnd.getAddress shouldBe addr


### PR DESCRIPTION
This pull request:

* Backports NAT fixes to v5.2.1-hf3 from midonet/master (cherrypicking commits)
* Fixes security group issue, when references to non-existing IP address groups were not deleted after security group was deleted, and caused midolman to fail.