### PR TITLE
WIP: Don't delete midolman socket on startup

### DIFF
--- a/midolman/src/main/scala/org/midonet/services/rest_api/BindingApiService.scala
+++ b/midolman/src/main/scala/org/midonet/services/rest_api/BindingApiService.scala
@@ -104,7 +104,6 @@ class BindingApiService @Inject()(nodeContext: Context,
         try {
             try {
                 val file = new File(socketPath)
-                file.delete
                 file.getParentFile.mkdirs
             } catch {
                 case NonFatal(e) => // ok to ignore


### PR DESCRIPTION
This makes it possible to set permissions via ansible persistently.

It is necessary if other users than root should be able to talk to the socket.