### PR TITLE
WIP: Don't delete midolman socket on startup

### DIFF
--- a/midolman/src/main/scala/org/midonet/services/rest_api/RestApiService.scala
+++ b/midolman/src/main/scala/org/midonet/services/rest_api/RestApiService.scala
@@ -109,7 +109,6 @@ class RestApiService @Inject()(
         try {
             try {
                 val file = new File(socketPath)
-                file.delete
                 file.getParentFile.mkdirs
             } catch {
                 case NonFatal(e) => // ok to ignore


### PR DESCRIPTION
This makes it possible to set permissions via ansible persistently.

It is necessary if other users than root should be able to talk to the socket.