### PR TITLE
os-3020 Limit ZOOM provenance to 20 entries

### DIFF
--- a/nsdb/src/test/scala/org/midonet/cluster/data/storage/ZookeeperObjectMapperTest.scala
+++ b/nsdb/src/test/scala/org/midonet/cluster/data/storage/ZookeeperObjectMapperTest.scala
@@ -1021,10 +1021,19 @@ class ZookeeperObjectMapperTest extends StorageTest with MidonetBackendTest
             When("Updating the network in storage")
             zoom.tryTransaction(ZoomOwner.ClusterNeutron) { _.update(network) }
 
+            Then("The provenance data is not updated")
+            obj = ZoomObject.parseFrom(curator.getData.forPath(path))
+            obj.getProvenanceCount shouldBe 2
+            obj.getProvenance(1).getChangeOwner shouldBe ZoomOwner.ClusterApi.id
+            obj.getProvenance(1).getChangeType shouldBe ZoomChange.Data.id
+
+            When("Updating the network in storage")
+            zoom.tryTransaction(ZoomOwner.AgentBinding) { _.update(network) }
+
             Then("The provenance data is updated")
             obj = ZoomObject.parseFrom(curator.getData.forPath(path))
             obj.getProvenanceCount shouldBe 3
-            obj.getProvenance(2).getChangeOwner shouldBe ZoomOwner.ClusterNeutron.id
+            obj.getProvenance(2).getChangeOwner shouldBe ZoomOwner.AgentBinding.id
             obj.getProvenance(2).getChangeType shouldBe ZoomChange.Data.id
         }
     }


### PR DESCRIPTION
Limit ZOOM provenance data to 20 entries

And don't add new provenance entry if the owner is the same as one of the last
two (changed from only looking at the last one).

Fixes an issue where the provenance data for Host objects grew and grew because
owners alternated between ClusterApi and AgentBinding.
With the change here the provenance list should only contain two entries, one
for ClusterApi, one for AgentBinding.
There may be other scenarios with more owners or changing product versions.
To avoid running into problems (huge provenance lists) only the last 20
entries are kept.