### PR TITLE
os-3062 ZookeeperObjectMapper: take zookeeper lock per transaction retry

### DIFF
--- a/nsdb/src/main/scala/org/midonet/cluster/data/storage/ZookeeperObjectMapper.scala
+++ b/nsdb/src/main/scala/org/midonet/cluster/data/storage/ZookeeperObjectMapper.scala
@@ -881,27 +881,24 @@ class ZookeeperObjectMapper(config: MidonetBackendConfig,
     @throws[StorageException]
     override def tryTransaction[R](owner: ZoomOwner)(f: (Transaction) => R): R = {
         val lock =
-            if (!lockFree) new InterProcessSemaphoreMutex(curator, topologyLockPath)
-            else null
-        if ((lock eq null) ||
-            lock.acquire(config.lockTimeoutMs, TimeUnit.MILLISECONDS)) {
-            try TransactionRetriable.retry(Log, "Transaction") {
-                val tx = transaction(owner)
-                try {
-                    val result = f(tx)
-                    tx.commit()
-                    result
-                } finally {
-                    tx.close()
-                }
+        if (!lockFree) new InterProcessSemaphoreMutex(curator, topologyLockPath)
+        else null
+        TransactionRetriable.retry(Log, "Transaction") {
+            if ((lock ne null) && !lock.acquire(config.lockTimeoutMs, TimeUnit.MILLISECONDS)) {
+                throw new StorageException("Acquiring lock timed-out after " +
+                                           s"${config.lockTimeoutMs} ms")
+            }
+            val tx = transaction(owner)
+            try {
+                val result = f(tx)
+                tx.commit()
+                result
             } finally {
+                tx.close()
                 if ((lock ne null) && lock.isAcquiredInThisProcess) {
                     lock.release()
                 }
             }
-        } else {
-            throw new StorageException("Acquiring lock timed-out after " +
-                                       s"${config.lockTimeoutMs} ms")
         }
     }
 

--- a/nsdb/src/main/scala/org/midonet/cluster/data/storage/ZookeeperObjectMapper.scala
+++ b/nsdb/src/main/scala/org/midonet/cluster/data/storage/ZookeeperObjectMapper.scala
@@ -881,8 +881,8 @@ class ZookeeperObjectMapper(config: MidonetBackendConfig,
     @throws[StorageException]
     override def tryTransaction[R](owner: ZoomOwner)(f: (Transaction) => R): R = {
         val lock =
-        if (!lockFree) new InterProcessSemaphoreMutex(curator, topologyLockPath)
-        else null
+            if (!lockFree) new InterProcessSemaphoreMutex(curator, topologyLockPath)
+            else null
         TransactionRetriable.retry(Log, "Transaction") {
             if ((lock ne null) && !lock.acquire(config.lockTimeoutMs, TimeUnit.MILLISECONDS)) {
                 throw new StorageException("Acquiring lock timed-out after " +


### PR DESCRIPTION
don't keep the lock across retries, avoids to stay in critical section for too long