### PR TITLE
os-3382 Move HAPROXY ServiceContainer creation to when HM is created

### DIFF
--- a/midonet-cluster/src/test/scala/org/midonet/cluster/services/c3po/translators/HealthMonitorV2IT.scala
+++ b/midonet-cluster/src/test/scala/org/midonet/cluster/services/c3po/translators/HealthMonitorV2IT.scala
@@ -23,12 +23,15 @@ import org.midonet.cluster.C3POMinionTestBase
 import org.midonet.cluster.data.neutron.NeutronResourceType.{HealthMonitorV2 => HealthMonitorV2Type}
 import org.midonet.cluster.models.Topology._
 import org.midonet.cluster.services.c3po.LbaasV2ITCommon
+import org.midonet.cluster.services.rest_api.resources.ServiceContainerGroupResource
 import org.midonet.cluster.util.UUIDUtil._
 import org.midonet.util.concurrent.toFutureOps
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class HealthMonitorV2IT extends C3POMinionTestBase with LbaasV2ITCommon {
+class HealthMonitorV2IT extends C3POMinionTestBase
+                        with LbaasV2ITCommon
+                        with LoadBalancerManager {
 
     private def verifyHealthMonitor(id: UUID,
                                     delay: Int,
@@ -65,6 +68,34 @@ class HealthMonitorV2IT extends C3POMinionTestBase with LbaasV2ITCommon {
         val pool2 = storage.get(classOf[Pool], pool1Id).await()
         pool2.getHealthMonitorId shouldBe toProto(hmId)
 
+        val lb = storage.get(classOf[LoadBalancer], lbId).await()
+        val routerId = fromProto(lb.getRouterId)
+        val lbSCId = lbServiceContainerId(routerId)
+        val lbSCGId = lbServiceContainerGroupId(routerId)
+        val lbSCPId = lbServiceContainerPortId(routerId)
+
+        lb.getServiceContainerId shouldBe toProto(lbSCId)
+
+        val sc = storage.get(classOf[ServiceContainer], lbSCId).await()
+        sc.getPortId shouldBe toProto(lbSCPId)
+        sc.getConfigurationId shouldBe toProto(lb.getId)
+        sc.getServiceGroupId shouldBe toProto(lbSCGId)
+        sc.getServiceType shouldBe "HAPROXY"
+
+        val scg = storage.get(classOf[ServiceContainerGroup], lbSCGId).await()
+        scg.getServiceContainerIdsList should contain only lbSCId
+
+        val scp = storage.get(classOf[Port], lbSCPId).await()
+        scp.getRouterId shouldBe toProto(routerId)
+        scp.hasPortMac shouldBe true
+        scp.hasPortAddress shouldBe true
+        scp.getPortSubnetCount shouldBe 1
+        scp.getAdminStateUp shouldBe true
+
+        var router = storage.get(classOf[Router], routerId).await()
+        router.getPortIdsCount shouldBe 2
+        router.getPortIdsList should contain (toProto(lbSCPId))
+
         updateHealthMonitorV2(50, hmId, delay = 5, timeout = 6,
                               maxRetries = 7, adminStateUp = true)
         verifyHealthMonitor(hmId, delay = 5, timeout = 6, maxRetries = 7,
@@ -72,5 +103,12 @@ class HealthMonitorV2IT extends C3POMinionTestBase with LbaasV2ITCommon {
 
         insertDeleteTask(60, HealthMonitorV2Type, hmId)
         storage.exists(classOf[HealthMonitor], hmId).await() shouldBe false
+        storage.exists(classOf[ServiceContainer], lbSCId).await() shouldBe false
+        storage.exists(classOf[ServiceContainerGroup], lbSCGId).await() shouldBe false
+        storage.exists(classOf[Port], lbSCPId).await() shouldBe false
+        router = storage.get(classOf[Router], routerId).await()
+        router.getPortIdsCount shouldBe 1
+        router.getPortIdsList should not contain (toProto(lbSCPId))
+
     }
 }


### PR DESCRIPTION
Don't create the HAPROXY ServiceContainer and its Port when the LoadBalancer
is created but wait for the HealthMonitor. The service container won't start
as long as there's no HealthMonitor. And if a LoadBalancer is set up without
a HealthMonitor the service container will never start. Trying to schedule
it to some host doesn't make sense. It times out and is re-scheduled to a
different host over and over again. That in turn creates a lot of
Zookeeper watchers in midolman (Port host_id changes, midolman updates
observable on /midonet/zoom/0/state/<host-id>/Port/<port-id>/active,
old watcher is closed, new watcher is started). But the old watcher isn't
really removed from Zookeeper, only partly in Curator --> we have a leak.

With the changes here the ServiceContainerGroup, ServiceContainer and Port
for the health monitoring (haproxy) are only created when the HealthMonitor
is created.