### PR TITLE
Configurable flow expiration

### DIFF
--- a/midolman/src/main/resources/org/midonet/conf/schemas/agent.conf
+++ b/midolman/src/main/resources/org/midonet/conf/schemas/agent.conf
@@ -83,6 +83,11 @@ fail over to another zookeeper server without traffic disruption."""
         the MidoNet agent will check and clean up expired flows."""
         check_flow_expiration_interval_type : "duration"
 
+        flow_expiration : 60s
+        flow_expiration_description : """The time after which a flow expires.
+        """
+        flow_expiration_type : "duration"
+
         bgp_keepalive : 60s
         bgp_keepalive_description : """
         Time between transmission of keepalive packets. """

--- a/midolman/src/main/scala/org/midonet/midolman/config/MidolmanConfig.scala
+++ b/midolman/src/main/scala/org/midonet/midolman/config/MidolmanConfig.scala
@@ -86,6 +86,7 @@ class MidolmanConfig(config: Config, val schema: Config = ConfigFactory.empty(),
     def outputChannels = getInt(s"$PREFIX.midolman.output_channels")
     def inputChannelThreading = getString(s"$PREFIX.midolman.input_channel_threading")
     def datapathName = Try(getString(s"$PREFIX.midolman.datapath")).getOrElse("midonet")
+    def flowExpirationTime = getDuration(s"$PREFIX.midolman.flow_expiration", TimeUnit.SECONDS)
 
     def lockMemory = getBoolean(s"$PREFIX.midolman.lock_memory")
 

--- a/midolman/src/main/scala/org/midonet/midolman/flows/FlowExpirationIndexer.scala
+++ b/midolman/src/main/scala/org/midonet/midolman/flows/FlowExpirationIndexer.scala
@@ -19,30 +19,25 @@ package org.midonet.midolman.flows
 import java.util.ArrayDeque
 
 import scala.concurrent.duration._
-
 import org.midonet.midolman.logging.MidolmanLogging
 import org.midonet.packets.{FlowStateStore => FlowState}
 import org.midonet.midolman.FlowTablePreallocation
+import org.midonet.midolman.config.MidolmanConfig
 
 object FlowExpirationIndexer {
     sealed abstract class Expiration {
-        def value: Long
         val typeId: Int
     }
     object ERROR_CONDITION_EXPIRATION extends Expiration {
-        val value = (5 seconds).toNanos
         val typeId = 0
     }
     object FLOW_EXPIRATION extends Expiration {
-        var value = (1 minutes).toNanos
         val typeId = 1
     }
     object STATEFUL_FLOW_EXPIRATION extends Expiration {
-        val value = FlowState.DEFAULT_EXPIRATION.toNanos / 2
         val typeId = 2
     }
     object TUNNEL_FLOW_EXPIRATION extends Expiration {
-        def value = FLOW_EXPIRATION.value * 5
         val typeId = 3
     }
 
@@ -75,9 +70,18 @@ object FlowExpirationIndexer {
  * but it is still kept in these data structures until it expires. This is to
  * avoid linear remove operations or smarter, more expensive data structures.
  */
-class FlowExpirationIndexer(preallocation: FlowTablePreallocation)
+class FlowExpirationIndexer(config: MidolmanConfig, preallocation: FlowTablePreallocation)
         extends MidolmanLogging {
     import FlowExpirationIndexer._
+
+    val flowExpirationDuration = config.flowExpirationTime seconds
+
+    def expirationInterval(expiration: Expiration) : Long = expiration match {
+        case ERROR_CONDITION_EXPIRATION => (5 seconds).toNanos
+        case FLOW_EXPIRATION => flowExpirationDuration.toNanos
+        case STATEFUL_FLOW_EXPIRATION => flowExpirationDuration.toNanos / 2
+        case TUNNEL_FLOW_EXPIRATION => flowExpirationDuration.toNanos * 5
+    }
 
     private val expirationQueues = new Array[ExpirationQueue](maxType)
 
@@ -93,9 +97,9 @@ class FlowExpirationIndexer(preallocation: FlowTablePreallocation)
     }
 
     def enqueueFlowExpiration(flowId: ManagedFlow.FlowId,
-                            expiration: Long,
-                            expirationType: Int): Unit = {
-        expirationQueues(expirationType).add(flowId, expiration)
+                              now: Long,
+                              expiration: Expiration): Unit = {
+        expirationQueues(expiration.typeId).add(flowId, now + expirationInterval(expiration))
     }
 
     def pollForExpired(now: Long): ManagedFlow.FlowId = {

--- a/midolman/src/main/scala/org/midonet/midolman/flows/ManagedFlow.scala
+++ b/midolman/src/main/scala/org/midonet/midolman/flows/ManagedFlow.scala
@@ -53,8 +53,9 @@ final class ManagedFlowImpl(override val pool: ObjectPool[ManagedFlowImpl])
     val callbacks = new ArrayList[Callback0]()
     val tags = new ArrayList[FlowTag]
     override val flowMatch = new FlowMatch()
-    var expirationType = 0
-    var absoluteExpirationNanos = 0L
+    var expiration: Expiration = FlowExpirationIndexer.FLOW_EXPIRATION
+    // when was the flow reset? In nanoseconds, based on NanoClock tick.
+    var absoluteResetTimeNanos = 0L
     // To synchronize create operation with delete operations
     var _sequence = 0L
     // To access this object from a netlink sequence number, used for duplicate detection
@@ -67,11 +68,11 @@ final class ManagedFlowImpl(override val pool: ObjectPool[ManagedFlowImpl])
 
     def reset(flowMatch: FlowMatch, flowTags: ArrayList[FlowTag],
               flowRemovedCallbacks: ArrayList[Callback0], sequence: Long,
-              expiration: Expiration, now: Long,
+              exp: Expiration, now: Long,
               linkedFlow: ManagedFlowImpl = null): Unit = {
         this.flowMatch.resetWithoutIcmpData(flowMatch)
-        expirationType = expiration.typeId
-        absoluteExpirationNanos = now + expiration.value
+        expiration = exp
+        absoluteResetTimeNanos = now
         ArrayListUtil.addAll(flowTags, tags)
         ArrayListUtil.addAll(flowRemovedCallbacks, callbacks)
         this._sequence = sequence

--- a/midolman/src/test/scala/org/midonet/midolman/FlowControllerTest.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/FlowControllerTest.scala
@@ -125,7 +125,7 @@ class FlowControllerTest extends MidolmanSpec {
             managedFlow.currentRefCount should be (1)
 
             When("We expire the flow")
-            clock.time = FlowExpirationIndexer.FLOW_EXPIRATION.value + 1
+            clock.time = flowController.expirationInterval(FlowExpirationIndexer.FLOW_EXPIRATION) + 1
             flowController.process()
 
             Then("The datapath flow metric should be set at the original value")
@@ -169,7 +169,7 @@ class FlowControllerTest extends MidolmanSpec {
             managedFlow.currentRefCount should be (1)
 
             When("We expire the flow")
-            clock.time = FlowExpirationIndexer.FLOW_EXPIRATION.value + 1
+            clock.time = flowController.expirationInterval(FlowExpirationIndexer.FLOW_EXPIRATION) + 1
             flowController.process()
 
             Then("Nothing should happen, expiration doesn't keep refs")

--- a/midolman/src/test/scala/org/midonet/midolman/util/MidolmanServices.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/util/MidolmanServices.scala
@@ -127,6 +127,8 @@ trait MidolmanServices {
         override def invalidateFlowsFor(tag: FlowTag) = tags = tags :+ tag
         override def recordPacket(packetLen: Int,
                                   tags: ArrayList[FlowTag]): Unit = {}
+
+        override def expirationInterval(expiration: Expiration): Long = 1
     }
 
     def dpConn()(implicit ec: ExecutionContext, as: ActorSystem):


### PR DESCRIPTION
Added configuration option agent.midolman.flow_expiration.
Default is 60 seconds which was the previously hard-coded value.