### PR TITLE
Remember haproxy state.

### DIFF
--- a/midolman/build.gradle
+++ b/midolman/build.gradle
@@ -246,7 +246,7 @@ packaging {
     vendor = project.vendor
     url = project.url
     description = 'Midolman is a virtual network controller'
-    dependencies = ['haproxy']
+    dependencies = ['haproxy', 'netcat']
     confFiles = ['/etc/midolman/midolman-env.sh',
                  '/etc/midolman/midolman-env.sh.compute.large',
                  '/etc/midolman/midolman-env.sh.gateway.large',

--- a/midolman/src/lib/midolman/service_containers/haproxy/haproxy-helper
+++ b/midolman/src/lib/midolman/service_containers/haproxy/haproxy-helper
@@ -51,6 +51,7 @@ makens() {
 
 restart_ha() {
     # Kill every process running in the namespace
+    echo "show servers state" | nc -U $SOCK > $SERVER_STATE
     for pid in $(ip netns pids $NAME)
     do
         kill -9 $pid
@@ -114,9 +115,11 @@ case $ACTION in
     restart_ha)
         NAME=$1
         CONF=$2
-        if [ "$#" -ne 2 ]; then
-            echo "expected 3 arguments, but $(($# + 1)) supplied"
-            echo "$0 restart_ha NAME CONF_FILE"
+        SOCK=$3
+        SERVER_STATE=$4
+        if [ "$#" -ne 4 ]; then
+            echo "expected 4 arguments, but $(($# + 1)) supplied"
+            echo "$0 restart_ha NAME CONF_FILE SOCK_FILE SERVER_STATE_FILE"
             exit 1
         fi
         restart_ha

--- a/midolman/src/lib/midolman/service_containers/haproxy/haproxy-helper
+++ b/midolman/src/lib/midolman/service_containers/haproxy/haproxy-helper
@@ -50,8 +50,10 @@ makens() {
 }
 
 restart_ha() {
-    # Kill every process running in the namespace
+    # Eliminate downtime by transferring the server state from the currently running instance.
+    # If haproxy is not running for some reason, the state file will be empty. HAProxy is fine with that.
     echo "show servers state" | nc -U $SOCK > $SERVER_STATE
+    # Kill every process running in the namespace
     for pid in $(ip netns pids $NAME)
     do
         kill -9 $pid

--- a/midolman/src/main/scala/org/midonet/midolman/haproxy/HaproxyHelper.scala
+++ b/midolman/src/main/scala/org/midonet/midolman/haproxy/HaproxyHelper.scala
@@ -25,6 +25,7 @@ object HaproxyHelper {
     def namespaceName(id: String) = s"hm-${id.substring(0, 8)}"
     def confLocation(path: String) = s"$path/conf"
     def sockLocation(path: String) = s"$path/sock"
+    def stateLocation(path: String) = s"$path/state"
 }
 
 class HaproxyHelper(haproxyScript: String = "/usr/lib/midolman/haproxy-helper")
@@ -35,6 +36,7 @@ class HaproxyHelper(haproxyScript: String = "/usr/lib/midolman/haproxy-helper")
 
     var confLoc: String = _
     var sockLoc: String = _
+    var stateLoc: String = _
 
     private def makensStr(name: String, iface: String, ip: String,
                           routerIp: String) = {
@@ -46,7 +48,7 @@ class HaproxyHelper(haproxyScript: String = "/usr/lib/midolman/haproxy-helper")
     }
 
     private def restartHaproxyStr(name: String) = {
-        s"$haproxyScript restart_ha $name $confLoc"
+        s"$haproxyScript restart_ha $name $confLoc $sockLoc $stateLoc"
     }
 
     private def ensureConfDir(lbV2Config: LoadBalancerV2Config): Unit = {
@@ -54,12 +56,13 @@ class HaproxyHelper(haproxyScript: String = "/usr/lib/midolman/haproxy-helper")
             val haproxyPath = Files.createTempDirectory(lbV2Config.id.toString)
             confLoc = confLocation(haproxyPath.toString)
             sockLoc = sockLocation(haproxyPath.toString)
+            stateLoc = stateLocation(haproxyPath.toString)
         }
     }
 
     def writeConfFile(lbV2Config: LoadBalancerV2Config): Unit = {
         ensureConfDir(lbV2Config)
-        val contents = lbV2Config.generateConfigFile(sockLoc)
+        val contents = lbV2Config.generateConfigFile(sockLoc, stateLoc)
         writeFile(contents, confLoc)
     }
 

--- a/midolman/src/main/scala/org/midonet/midolman/l4lb/LoadBalancerV2Config.scala
+++ b/midolman/src/main/scala/org/midonet/midolman/l4lb/LoadBalancerV2Config.scala
@@ -36,7 +36,7 @@ case class LoadBalancerV2Config(id: UUID,
                                 pools: Set[PoolV2Config],
                                 adminStateUp: Boolean) {
 
-    def generateConfigFile(sockFile: String): String = {
+    def generateConfigFile(sockFile: String, stateFile: String): String = {
         val conf = new StringBuilder()
         conf append
             s"""
@@ -47,12 +47,14 @@ case class LoadBalancerV2Config(id: UUID,
                 |    log /dev/log local0
                 |    log /dev/log local1 notice
                 |    stats socket $sockFile mode 0666 level user
+                |    server-state-file $stateFile
                 |defaults
                 |    log global
                 |    retries 3
                 |    timeout connect 5000
                 |    timeout client 5000
                 |    timeout server 5000
+                |    load-server-state-from-file global
                 |""".stripMargin
 
         vips filter (_.adminStateUp) foreach { v =>


### PR DESCRIPTION
Improve health monitoring

Fixes the following issue:
Midolman restarts the haproxy process that's used to monitor the health of pool members whenever something changes in the LBaaS pool (config and/or member state). When haproxy starts again the initial state of pool members is assumed as "UP", even if it was "DOWN" before the restart and is still "DOWN".

Implemented solution: Save the servers state before restarting haproxy, let haproxy read the saved state on startup.