### PR TITLE
IPSEC: let pluto log into plain file

### DIFF
--- a/midolman/src/main/resources/org/midonet/conf/schemas/agent.conf
+++ b/midolman/src/main/resources/org/midonet/conf/schemas/agent.conf
@@ -520,16 +520,17 @@ service will update the status in NSDB."""
         ipsec {
             logging_enabled : true
             logging_enabled_description : """
+[Not used]
 Whether the IPSec container relays the log message from the IPSec process
 running inside the container to the agent log."""
 
             logging_poll_interval : 250ms
             logging_poll_interval_description : """
-Polling interval for the IPSec process log."""
+[Not used] Polling interval for the IPSec process log."""
 
             logging_timeout : 3s
             logging_timeout_description : """
-Timeout for an I/O operation on the IPSec process log file."""
+[Not used] Timeout for an I/O operation on the IPSec process log file."""
             logging_timeout_type : "duration"
 
             status_update_interval : 5s

--- a/midolman/src/main/scala/org/midonet/midolman/config/MidolmanConfig.scala
+++ b/midolman/src/main/scala/org/midonet/midolman/config/MidolmanConfig.scala
@@ -232,11 +232,11 @@ class ContainerConfig(val conf: Config, val schema: Config) extends TypeFailureF
 
 class IPSecContainerConfig(val conf: Config, val schema: Config) extends TypeFailureFallback {
     val prefix = "agent.containers.ipsec"
-    def loggingEnabled = getBoolean(s"$prefix.logging_enabled")
-    def loggingPollInterval = getDuration(s"$prefix.logging_poll_interval",
-                                          TimeUnit.MILLISECONDS) millis
-    def loggingTimeout = getDuration(s"$prefix.logging_timeout",
-                                     TimeUnit.MILLISECONDS) millis
+    // def loggingEnabled = getBoolean(s"$prefix.logging_enabled")
+    // def loggingPollInterval = getDuration(s"$prefix.logging_poll_interval",
+    //                                       TimeUnit.MILLISECONDS) millis
+    // def loggingTimeout = getDuration(s"$prefix.logging_timeout",
+    //                                  TimeUnit.MILLISECONDS) millis
     def statusUpdateInterval = getDuration(s"$prefix.status_update_interval",
                                            TimeUnit.MILLISECONDS) millis
 }

--- a/midolman/src/test/scala/org/midonet/containers/IPSecContainerTest.scala
+++ b/midolman/src/test/scala/org/midonet/containers/IPSecContainerTest.scala
@@ -559,17 +559,15 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             container.commands(0) shouldBe s"vpn-helper prepare"
             container.commands(1) shouldBe s"vpn-helper cleanns -n ${vpn.name}"
             container.commands(2) shouldBe
-                s"mkfifo -m 0600 ${vpn.filepath}/var/run/pluto.log"
-            container.commands(3) shouldBe
                 s"vpn-helper makens -n ${vpn.name} " +
                 s"-g ${vpn.namespaceGatewayIp} " +
                 s"-G ${vpn.namespaceGatewayMac} " +
                 s"-l ${vpn.localEndpointIp} " +
                 s"-i ${vpn.namespaceInterfaceIp} " +
                 s"-m ${vpn.localEndpointMac}"
-            container.commands(4) shouldBe
+            container.commands(3) shouldBe
                 s"vpn-helper start_service -n ${vpn.name} -p ${vpn.filepath}"
-            container.commands(5) shouldBe
+            container.commands(4) shouldBe
                 s"vpn-helper init_conns -n ${vpn.name} -p ${vpn.filepath} " +
                 s"-g ${vpn.namespaceGatewayIp} " +
                 s"-c ${IPSecConfig.vpnName(conn.getId.asJava)}"
@@ -578,13 +576,45 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             container.cleanup(conf)
 
             Then("The container should execute the cleanup commands")
-            container.commands(6) shouldBe
+            container.commands(5) shouldBe
                 s"vpn-helper stop_service -n ${vpn.name} -p ${vpn.filepath}"
-            container.commands(7) shouldBe
+            container.commands(6) shouldBe
                 s"vpn-helper cleanns -n ${vpn.name}"
         }
 
         scenario("Changes rolled back when creating the namespace fails") {
+            Given("A VPN configuration")
+            val (vpn, ike, ipsec, conn) = createService()
+
+            And("An IPSec configuration")
+            val conf = new IPSecConfig("vpn-helper", vpn, Seq(conn))
+
+            And("A container")
+            val container = new TestIPSecContainer(vt, containerExecutor)
+
+            When("Calling the setup method should fail")
+            container.failOn = 3
+            intercept[IPSecException] {
+                container.setup(conf)
+            }
+
+            Then("The container should execute the setup commands")
+            container.commands(0) shouldBe s"vpn-helper prepare"
+            container.commands(1) shouldBe s"vpn-helper cleanns -n ${vpn.name}"
+            container.commands(2) shouldBe
+                s"vpn-helper makens -n ${vpn.name} " +
+                s"-g ${vpn.namespaceGatewayIp} " +
+                s"-G ${vpn.namespaceGatewayMac} " +
+                s"-l ${vpn.localEndpointIp} " +
+                s"-i ${vpn.namespaceInterfaceIp} " +
+                s"-m ${vpn.localEndpointMac}"
+
+            And("The container should execute the cleanup commands")
+            container.commands(3) shouldBe
+                s"vpn-helper cleanns -n ${vpn.name}"
+        }
+
+        scenario("Changes rolled back when starting the service fails") {
             Given("A VPN configuration")
             val (vpn, ike, ipsec, conn) = createService()
 
@@ -604,21 +634,23 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             container.commands(0) shouldBe s"vpn-helper prepare"
             container.commands(1) shouldBe s"vpn-helper cleanns -n ${vpn.name}"
             container.commands(2) shouldBe
-                s"mkfifo -m 0600 ${vpn.filepath}/var/run/pluto.log"
-            container.commands(3) shouldBe
                 s"vpn-helper makens -n ${vpn.name} " +
                 s"-g ${vpn.namespaceGatewayIp} " +
                 s"-G ${vpn.namespaceGatewayMac} " +
                 s"-l ${vpn.localEndpointIp} " +
                 s"-i ${vpn.namespaceInterfaceIp} " +
                 s"-m ${vpn.localEndpointMac}"
+            container.commands(3) shouldBe
+                s"vpn-helper start_service -n ${vpn.name} -p ${vpn.filepath}"
 
             And("The container should execute the cleanup commands")
             container.commands(4) shouldBe
+                s"vpn-helper stop_service -n ${vpn.name} -p ${vpn.filepath}"
+            container.commands(5) shouldBe
                 s"vpn-helper cleanns -n ${vpn.name}"
         }
 
-        scenario("Changes rolled back when starting the service fails") {
+        scenario("Changes rolled back when initiating the connections fails") {
             Given("A VPN configuration")
             val (vpn, ike, ipsec, conn) = createService()
 
@@ -638,63 +670,23 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             container.commands(0) shouldBe s"vpn-helper prepare"
             container.commands(1) shouldBe s"vpn-helper cleanns -n ${vpn.name}"
             container.commands(2) shouldBe
-                s"mkfifo -m 0600 ${vpn.filepath}/var/run/pluto.log"
-            container.commands(3) shouldBe
                 s"vpn-helper makens -n ${vpn.name} " +
                 s"-g ${vpn.namespaceGatewayIp} " +
                 s"-G ${vpn.namespaceGatewayMac} " +
                 s"-l ${vpn.localEndpointIp} " +
                 s"-i ${vpn.namespaceInterfaceIp} " +
                 s"-m ${vpn.localEndpointMac}"
-            container.commands(4) shouldBe
-                s"vpn-helper start_service -n ${vpn.name} -p ${vpn.filepath}"
-
-            And("The container should execute the cleanup commands")
-            container.commands(5) shouldBe
-                s"vpn-helper stop_service -n ${vpn.name} -p ${vpn.filepath}"
-            container.commands(6) shouldBe
-                s"vpn-helper cleanns -n ${vpn.name}"
-        }
-
-        scenario("Changes rolled back when initiating the connections fails") {
-            Given("A VPN configuration")
-            val (vpn, ike, ipsec, conn) = createService()
-
-            And("An IPSec configuration")
-            val conf = new IPSecConfig("vpn-helper", vpn, Seq(conn))
-
-            And("A container")
-            val container = new TestIPSecContainer(vt, containerExecutor)
-
-            When("Calling the setup method should fail")
-            container.failOn = 6
-            intercept[IPSecException] {
-                container.setup(conf)
-            }
-
-            Then("The container should execute the setup commands")
-            container.commands(0) shouldBe s"vpn-helper prepare"
-            container.commands(1) shouldBe s"vpn-helper cleanns -n ${vpn.name}"
-            container.commands(2) shouldBe
-                s"mkfifo -m 0600 ${vpn.filepath}/var/run/pluto.log"
             container.commands(3) shouldBe
-                s"vpn-helper makens -n ${vpn.name} " +
-                s"-g ${vpn.namespaceGatewayIp} " +
-                s"-G ${vpn.namespaceGatewayMac} " +
-                s"-l ${vpn.localEndpointIp} " +
-                s"-i ${vpn.namespaceInterfaceIp} " +
-                s"-m ${vpn.localEndpointMac}"
-            container.commands(4) shouldBe
                 s"vpn-helper start_service -n ${vpn.name} -p ${vpn.filepath}"
-            container.commands(5) shouldBe
+            container.commands(4) shouldBe
                 s"vpn-helper init_conns -n ${vpn.name} -p ${vpn.filepath} " +
                 s"-g ${vpn.namespaceGatewayIp} " +
                 s"-c ${IPSecConfig.vpnName(conn.getId.asJava)}"
 
             And("The container should execute the cleanup commands")
-            container.commands(6) shouldBe
+            container.commands(5) shouldBe
                 s"vpn-helper stop_service -n ${vpn.name} -p ${vpn.filepath}"
-            container.commands(7) shouldBe
+            container.commands(6) shouldBe
                 s"vpn-helper cleanns -n ${vpn.name}"
         }
     }
@@ -846,19 +838,19 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
                                                  port.getPortSubnet(0).getPrefixLength)
 
             Then("The container should call vpn setup commands")
-            container.commands should have size 7
+            container.commands should have size 6
 
             When("Clearing all vpn services from the router")
             vt.store.update(router.toBuilder.clearVpnServiceIds().build)
             router = vt.store.get(classOf[Router], router.getId).await()
 
             Then("The container should call cleanup commands")
-            container.commands should have size 9
-            container.commands(7) shouldBe
+            container.commands should have size 8
+            container.commands(6) shouldBe
                 s"/usr/lib/midolman/vpn-helper stop_service " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path"
-            container.commands(8) shouldBe
+            container.commands(7) shouldBe
                 s"/usr/lib/midolman/vpn-helper cleanns " +
                 s"-n ${port.getInterfaceName}"
 
@@ -876,14 +868,14 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             vt.store.multi(Seq(CreateOp(vpn), CreateOp(conn)))
 
             Then("The container should call vpn setup commands")
-            container.commands should have size 16
+            container.commands should have size 14
 
             When("Calling the delete method of the container")
             val vpnServiceSubscription = container.vpnServiceSubscription
             container.delete().await()
 
             Then("The container shouldn't call cleanup commands")
-            container.commands should have size 18
+            container.commands should have size 16
 
             And("The container should unsubscribe from the observable")
             vpnServiceSubscription.isUnsubscribed shouldBe true
@@ -931,13 +923,13 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             val namespaceSubnet = new IPv4Subnet(port.getPortAddress.asIPv4Address.next,
                                                  port.getPortSubnet(0).getPrefixLength)
 
-            container.commands should have size 7
+            container.commands should have size 6
             container.commands(0) shouldBe
                 s"/usr/lib/midolman/vpn-helper prepare"
             container.commands(1) shouldBe
                 s"/usr/lib/midolman/vpn-helper cleanns " +
                 s"-n ${port.getInterfaceName}"
-            container.commands(3) shouldBe
+            container.commands(2) shouldBe
                 s"/usr/lib/midolman/vpn-helper makens " +
                 s"-n ${port.getInterfaceName} " +
                 s"-g ${port.getPortAddress.asIPv4Address} " +
@@ -945,17 +937,17 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
                 s"-l ${port.getPortAddress.asIPv4Address} " +
                 s"-i $namespaceSubnet " +
                 s"-m ${port.getPortMac}"
-            container.commands(4) shouldBe
+            container.commands(3) shouldBe
                 s"/usr/lib/midolman/vpn-helper start_service " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path"
-            container.commands(5) shouldBe
+            container.commands(4) shouldBe
                 s"/usr/lib/midolman/vpn-helper init_conns " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path " +
                 s"-g ${port.getPortAddress.asIPv4Address} " +
                 s"-c ${IPSecConfig.vpnName(conn.getId.asJava)}"
-            container.commands(6) shouldBe
+            container.commands(5) shouldBe
                 "ip netns exec if-eth ipsec whack --status " +
                 s"--ctlbase $path/var/run/pluto"
 
@@ -964,11 +956,11 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             container.delete().await()
 
             Then("The container should call the cleanup commands")
-            container.commands(7) shouldBe
+            container.commands(6) shouldBe
                 s"/usr/lib/midolman/vpn-helper stop_service " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path"
-            container.commands(8) shouldBe
+            container.commands(7) shouldBe
                 s"/usr/lib/midolman/vpn-helper cleanns " +
                 s"-n ${port.getInterfaceName}"
 
@@ -1019,27 +1011,27 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             val namespaceSubnet = new IPv4Subnet(port.getPortAddress.asIPv4Address.next,
                                                  port.getPortSubnet(0).getPrefixLength)
 
-            container.commands should have size 7
+            container.commands should have size 6
 
             When("Calling the update method of the container")
             container.updated(cp).await()
 
             Then("The container should call the cleanup and setup commands")
-            container.commands should have size 16
+            container.commands should have size 14
 
-            container.commands(7) shouldBe
+            container.commands(6) shouldBe
                 s"/usr/lib/midolman/vpn-helper stop_service " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path"
+            container.commands(7) shouldBe
+                s"/usr/lib/midolman/vpn-helper cleanns " +
+                s"-n ${port.getInterfaceName}"
             container.commands(8) shouldBe
-                s"/usr/lib/midolman/vpn-helper cleanns " +
-                s"-n ${port.getInterfaceName}"
-            container.commands(9) shouldBe
                 s"/usr/lib/midolman/vpn-helper prepare"
-            container.commands(10) shouldBe
+            container.commands(9) shouldBe
                 s"/usr/lib/midolman/vpn-helper cleanns " +
                 s"-n ${port.getInterfaceName}"
-            container.commands(12) shouldBe
+            container.commands(10) shouldBe
                 s"/usr/lib/midolman/vpn-helper makens " +
                 s"-n ${port.getInterfaceName} " +
                 s"-g ${port.getPortAddress.asIPv4Address} " +
@@ -1047,17 +1039,17 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
                 s"-l ${port.getPortAddress.asIPv4Address} " +
                 s"-i $namespaceSubnet " +
                 s"-m ${port.getPortMac}"
-            container.commands(13) shouldBe
+            container.commands(11) shouldBe
                 s"/usr/lib/midolman/vpn-helper start_service " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path"
-            container.commands(14) shouldBe
+            container.commands(12) shouldBe
                 s"/usr/lib/midolman/vpn-helper init_conns " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path " +
                 s"-g ${port.getPortAddress.asIPv4Address} " +
                 s"-c ${IPSecConfig.vpnName(conn.getId.asJava)}"
-            container.commands(15) shouldBe
+            container.commands(13) shouldBe
                 "ip netns exec if-eth ipsec whack --status " +
                 s"--ctlbase $path/var/run/pluto"
 
@@ -1066,9 +1058,9 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             vpn = vt.store.get(classOf[VpnService], vpn.getId).await()
 
             Then("The container is deleted")
-            container.commands(16) shouldBe
+            container.commands(14) shouldBe
                 s"/usr/lib/midolman/vpn-helper stop_service -n ${port.getInterfaceName} -p $path"
-            container.commands(17) shouldBe
+            container.commands(15) shouldBe
                 s"/usr/lib/midolman/vpn-helper cleanns -n ${port.getInterfaceName}"
 
             When("Resetting the VpnService to admin state UP")
@@ -1076,12 +1068,12 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             vpn = vt.store.get(classOf[VpnService], vpn.getId).await()
 
             Then("The container should call the setup commands")
-            container.commands should have size 25
-            container.commands(18) shouldBe
+            container.commands should have size 22
+            container.commands(16) shouldBe
                 s"/usr/lib/midolman/vpn-helper prepare"
-            container.commands(19) shouldBe
+            container.commands(17) shouldBe
                 s"/usr/lib/midolman/vpn-helper cleanns -n ${port.getInterfaceName}"
-            container.commands(21) shouldBe
+            container.commands(18) shouldBe
                 s"/usr/lib/midolman/vpn-helper makens " +
                 s"-n ${port.getInterfaceName} " +
                 s"-g ${port.getPortAddress.asIPv4Address} " +
@@ -1089,17 +1081,17 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
                 s"-l ${port.getPortAddress.asIPv4Address} " +
                 s"-i $namespaceSubnet " +
                 s"-m ${port.getPortMac}"
-            container.commands(22) shouldBe
+            container.commands(19) shouldBe
                 s"/usr/lib/midolman/vpn-helper start_service " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path"
-            container.commands(23) shouldBe
+            container.commands(20) shouldBe
                 s"/usr/lib/midolman/vpn-helper init_conns " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path " +
                 s"-g ${port.getPortAddress.asIPv4Address} " +
                 s"-c ${IPSecConfig.vpnName(conn.getId.asJava)}"
-            container.commands(24) shouldBe
+            container.commands(21) shouldBe
                 "ip netns exec if-eth ipsec whack --status " +
                 s"--ctlbase $path/var/run/pluto"
 
@@ -1108,19 +1100,19 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             conn = vt.store.get(classOf[IPSecSiteConnection], conn.getId).await()
 
             Then("The container is torn down")
-            container.commands should have size 27
+            container.commands should have size 24
 
             When("Resetting the connection to admin state UP")
             vt.store.update(conn.toBuilder.setAdminStateUp(true).build())
             conn = vt.store.get(classOf[IPSecSiteConnection], conn.getId).await()
 
             Then("The container should call the setup commands")
-            container.commands should have size 34
-            container.commands(27) shouldBe
+            container.commands should have size 30
+            container.commands(24) shouldBe
                 s"/usr/lib/midolman/vpn-helper prepare"
-            container.commands(28) shouldBe
+            container.commands(25) shouldBe
                 s"/usr/lib/midolman/vpn-helper cleanns -n ${port.getInterfaceName}"
-            container.commands(30) shouldBe
+            container.commands(26) shouldBe
                 s"/usr/lib/midolman/vpn-helper makens " +
                 s"-n ${port.getInterfaceName} " +
                 s"-g ${port.getPortAddress.asIPv4Address} " +
@@ -1128,17 +1120,17 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
                 s"-l ${port.getPortAddress.asIPv4Address} " +
                 s"-i $namespaceSubnet " +
                 s"-m ${port.getPortMac}"
-            container.commands(31) shouldBe
+            container.commands(27) shouldBe
                 s"/usr/lib/midolman/vpn-helper start_service " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path"
-            container.commands(32) shouldBe
+            container.commands(28) shouldBe
                 s"/usr/lib/midolman/vpn-helper init_conns " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path " +
                 s"-g ${port.getPortAddress.asIPv4Address} " +
                 s"-c ${IPSecConfig.vpnName(conn.getId.asJava)}"
-            container.commands(33) shouldBe
+            container.commands(29) shouldBe
                 "ip netns exec if-eth ipsec whack --status " +
                 s"--ctlbase $path/var/run/pluto"
 
@@ -1147,12 +1139,12 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             container.delete().await()
 
             Then("The container should call the cleanup commands")
-            container.commands should have size 36
-            container.commands(34) shouldBe
+            container.commands should have size 32
+            container.commands(30) shouldBe
                 s"/usr/lib/midolman/vpn-helper stop_service " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path"
-            container.commands(35) shouldBe
+            container.commands(31) shouldBe
                 s"/usr/lib/midolman/vpn-helper cleanns " +
                 s"-n ${port.getInterfaceName}"
 
@@ -1213,13 +1205,13 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
                                                  port.getPortSubnet(0).getPrefixLength)
 
             Then("The container should call the cleanup and setup commands")
-            container.commands should have size 7
+            container.commands should have size 6
             container.commands(0) shouldBe
                 s"/usr/lib/midolman/vpn-helper prepare"
             container.commands(1) shouldBe
                 s"/usr/lib/midolman/vpn-helper cleanns " +
                 s"-n ${port.getInterfaceName}"
-            container.commands(3) shouldBe
+            container.commands(2) shouldBe
                 s"/usr/lib/midolman/vpn-helper makens " +
                 s"-n ${port.getInterfaceName} " +
                 s"-g ${port.getPortAddress.asIPv4Address} " +
@@ -1227,17 +1219,17 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
                 s"-l ${port.getPortAddress.asIPv4Address} " +
                 s"-i $namespaceSubnet " +
                 s"-m ${port.getPortMac}"
-            container.commands(4) shouldBe
+            container.commands(3) shouldBe
                 s"/usr/lib/midolman/vpn-helper start_service " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path"
-            container.commands(5) shouldBe
+            container.commands(4) shouldBe
                 s"/usr/lib/midolman/vpn-helper init_conns " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path " +
                 s"-g ${port.getPortAddress.asIPv4Address} " +
                 s"-c ${IPSecConfig.vpnName(conn.getId.asJava)}"
-            container.commands(6) shouldBe
+            container.commands(5) shouldBe
                 "ip netns exec if-eth ipsec whack --status " +
                 s"--ctlbase $path/var/run/pluto"
 
@@ -1246,7 +1238,7 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             container.delete().await()
 
             Then("The container should call the cleanup commands")
-            container.commands should have size 9
+            container.commands should have size 8
 
             And("The container should unsubscribe from the observable")
             vpnServiceSubscription.isUnsubscribed shouldBe true
@@ -1296,7 +1288,7 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             val namespaceSubnet = new IPv4Subnet(port.getPortAddress.asIPv4Address.next,
                                                  port.getPortSubnet(0).getPrefixLength)
 
-            container.commands should have size 7
+            container.commands should have size 6
 
             When("Adding a new ipsec connection to the vpn service")
             val conn2 = createIpsecSiteConnection(
@@ -1309,21 +1301,21 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             vt.store.create(conn2)
 
             Then("The container should call the cleanup and setup commands")
-            container.commands should have size 16
+            container.commands should have size 14
 
-            container.commands(7) shouldBe
+            container.commands(6) shouldBe
                 s"/usr/lib/midolman/vpn-helper stop_service " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path"
+            container.commands(7) shouldBe
+                s"/usr/lib/midolman/vpn-helper cleanns " +
+                s"-n ${port.getInterfaceName}"
             container.commands(8) shouldBe
-                s"/usr/lib/midolman/vpn-helper cleanns " +
-                s"-n ${port.getInterfaceName}"
-            container.commands(9) shouldBe
                 s"/usr/lib/midolman/vpn-helper prepare"
-            container.commands(10) shouldBe
+            container.commands(9) shouldBe
                 s"/usr/lib/midolman/vpn-helper cleanns " +
                 s"-n ${port.getInterfaceName}"
-            container.commands(12) shouldBe
+            container.commands(10) shouldBe
                 s"/usr/lib/midolman/vpn-helper makens " +
                 s"-n ${port.getInterfaceName} " +
                 s"-g ${port.getPortAddress.asIPv4Address} " +
@@ -1331,20 +1323,20 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
                 s"-l ${port.getPortAddress.asIPv4Address} " +
                 s"-i $namespaceSubnet " +
                 s"-m ${port.getPortMac}"
-            container.commands(13) shouldBe
+            container.commands(11) shouldBe
                 s"/usr/lib/midolman/vpn-helper start_service " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path"
-            container.commands(14).startsWith(
+            container.commands(12).startsWith(
                 s"/usr/lib/midolman/vpn-helper init_conns " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path " +
                 s"-g ${port.getPortAddress.asIPv4Address} ") shouldBe true
-            container.commands(14).contains(
+            container.commands(12).contains(
                 s"-c ${IPSecConfig.vpnName(conn1.getId.asJava)}") shouldBe true
-            container.commands(14).contains(
+            container.commands(12).contains(
                 s"-c ${IPSecConfig.vpnName(conn2.getId.asJava)}") shouldBe true
-            container.commands(15) shouldBe
+            container.commands(13) shouldBe
                 "ip netns exec if-eth ipsec whack --status " +
                 s"--ctlbase $path/var/run/pluto"
 
@@ -1353,20 +1345,20 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             conn1 = vt.store.get(classOf[IPSecSiteConnection], conn1.getId).await()
 
             Then("The container is torn down and setup with only one connection")
-            container.commands should have size 25
-            container.commands(16) shouldBe
+            container.commands should have size 22
+            container.commands(14) shouldBe
                 s"/usr/lib/midolman/vpn-helper stop_service " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path"
+            container.commands(15) shouldBe
+                s"/usr/lib/midolman/vpn-helper cleanns " +
+                s"-n ${port.getInterfaceName}"
+            container.commands(16) shouldBe
+                s"/usr/lib/midolman/vpn-helper prepare"
             container.commands(17) shouldBe
                 s"/usr/lib/midolman/vpn-helper cleanns " +
                 s"-n ${port.getInterfaceName}"
             container.commands(18) shouldBe
-                s"/usr/lib/midolman/vpn-helper prepare"
-            container.commands(19) shouldBe
-                s"/usr/lib/midolman/vpn-helper cleanns " +
-                s"-n ${port.getInterfaceName}"
-            container.commands(21) shouldBe
                 s"/usr/lib/midolman/vpn-helper makens " +
                 s"-n ${port.getInterfaceName} " +
                 s"-g ${port.getPortAddress.asIPv4Address} " +
@@ -1374,20 +1366,20 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
                 s"-l ${port.getPortAddress.asIPv4Address} " +
                 s"-i $namespaceSubnet " +
                 s"-m ${port.getPortMac}"
-            container.commands(22) shouldBe
+            container.commands(19) shouldBe
                 s"/usr/lib/midolman/vpn-helper start_service " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path"
-            container.commands(23).startsWith(
+            container.commands(20).startsWith(
                 s"/usr/lib/midolman/vpn-helper init_conns " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path " +
                 s"-g ${port.getPortAddress.asIPv4Address} ") shouldBe true
-            container.commands(23).contains(
+            container.commands(20).contains(
                 s"-c ${IPSecConfig.vpnName(conn1.getId.asJava)}") shouldBe false
-            container.commands(23).contains(
+            container.commands(20).contains(
                 s"-c ${IPSecConfig.vpnName(conn2.getId.asJava)}") shouldBe true
-            container.commands(24) shouldBe
+            container.commands(21) shouldBe
                 "ip netns exec if-eth ipsec whack --status " +
                 s"--ctlbase $path/var/run/pluto"
 
@@ -1396,20 +1388,20 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             conn1 = vt.store.get(classOf[IPSecSiteConnection], conn1.getId).await()
 
             Then("The container is torn down and setup with both connection")
-            container.commands should have size 34
-            container.commands(25) shouldBe
+            container.commands should have size 30
+            container.commands(22) shouldBe
                 s"/usr/lib/midolman/vpn-helper stop_service " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path"
-            container.commands(26) shouldBe
+            container.commands(23) shouldBe
                 s"/usr/lib/midolman/vpn-helper cleanns " +
                 s"-n ${port.getInterfaceName}"
-            container.commands(27) shouldBe
+            container.commands(24) shouldBe
                 s"/usr/lib/midolman/vpn-helper prepare"
-            container.commands(28) shouldBe
+            container.commands(25) shouldBe
                 s"/usr/lib/midolman/vpn-helper cleanns " +
                 s"-n ${port.getInterfaceName}"
-            container.commands(30) shouldBe
+            container.commands(26) shouldBe
                 s"/usr/lib/midolman/vpn-helper makens " +
                 s"-n ${port.getInterfaceName} " +
                 s"-g ${port.getPortAddress.asIPv4Address} " +
@@ -1417,20 +1409,20 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
                 s"-l ${port.getPortAddress.asIPv4Address} " +
                 s"-i $namespaceSubnet " +
                 s"-m ${port.getPortMac}"
-            container.commands(31) shouldBe
+            container.commands(27) shouldBe
                 s"/usr/lib/midolman/vpn-helper start_service " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path"
-            container.commands(32).startsWith(
+            container.commands(28).startsWith(
                 s"/usr/lib/midolman/vpn-helper init_conns " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path " +
                 s"-g ${port.getPortAddress.asIPv4Address} ") shouldBe true
-            container.commands(32).contains(
+            container.commands(28).contains(
                 s"-c ${IPSecConfig.vpnName(conn1.getId.asJava)}") shouldBe true
-            container.commands(32).contains(
+            container.commands(28).contains(
                 s"-c ${IPSecConfig.vpnName(conn2.getId.asJava)}") shouldBe true
-            container.commands(33) shouldBe
+            container.commands(29) shouldBe
                 "ip netns exec if-eth ipsec whack --status " +
                 s"--ctlbase $path/var/run/pluto"
 
@@ -1439,7 +1431,7 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             container.delete().await()
 
             Then("The container should call the cleanup commands")
-            container.commands should have size 36
+            container.commands should have size 32
 
             And("The container should unsubscribe from the observable")
             vpnSubscription.isUnsubscribed shouldBe true
@@ -1491,7 +1483,7 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             val namespaceSubnet = new IPv4Subnet(port.getPortAddress.asIPv4Address.next,
                                                  port.getPortSubnet(0).getPrefixLength)
 
-            container.commands should have size 7
+            container.commands should have size 6
 
             When("Adding a new VPN service with one ipsec connection")
             val vpn2 = createVpnService(
@@ -1507,21 +1499,21 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             vt.store.multi(Seq(CreateOp(vpn2), CreateOp(conn2)))
 
             Then("The container should call the cleanup and setup commands")
-            container.commands should have size 16
+            container.commands should have size 14
 
-            container.commands(7) shouldBe
+            container.commands(6) shouldBe
                 s"/usr/lib/midolman/vpn-helper stop_service " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path"
+            container.commands(7) shouldBe
+                s"/usr/lib/midolman/vpn-helper cleanns " +
+                s"-n ${port.getInterfaceName}"
             container.commands(8) shouldBe
-                s"/usr/lib/midolman/vpn-helper cleanns " +
-                s"-n ${port.getInterfaceName}"
-            container.commands(9) shouldBe
                 s"/usr/lib/midolman/vpn-helper prepare"
-            container.commands(10) shouldBe
+            container.commands(9) shouldBe
                 s"/usr/lib/midolman/vpn-helper cleanns " +
                 s"-n ${port.getInterfaceName}"
-            container.commands(12) shouldBe
+            container.commands(10) shouldBe
                 s"/usr/lib/midolman/vpn-helper makens " +
                 s"-n ${port.getInterfaceName} " +
                 s"-g ${port.getPortAddress.asIPv4Address} " +
@@ -1529,20 +1521,20 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
                 s"-l ${port.getPortAddress.asIPv4Address} " +
                 s"-i $namespaceSubnet " +
                 s"-m ${port.getPortMac}"
-            container.commands(13) shouldBe
+            container.commands(11) shouldBe
                 s"/usr/lib/midolman/vpn-helper start_service " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path"
-            container.commands(14).startsWith(
+            container.commands(12).startsWith(
                 s"/usr/lib/midolman/vpn-helper init_conns " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path " +
                 s"-g ${port.getPortAddress.asIPv4Address} ") shouldBe true
-            container.commands(14).contains(
+            container.commands(12).contains(
                 s"-c ${IPSecConfig.vpnName(conn1.getId.asJava)}") shouldBe true
-            container.commands(14).contains(
+            container.commands(12).contains(
                 s"-c ${IPSecConfig.vpnName(conn2.getId.asJava)}") shouldBe true
-            container.commands(15) shouldBe
+            container.commands(13) shouldBe
                 "ip netns exec if-eth ipsec whack --status " +
                 s"--ctlbase $path/var/run/pluto"
 
@@ -1550,20 +1542,20 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             vt.store.update(vpn1.toBuilder.setAdminStateUp(false).build())
             vpn1 = vt.store.get(classOf[VpnService], vpn1.getId).await()
             Then("The container is torn down and setup with only one connection")
-            container.commands should have size 25
-            container.commands(16) shouldBe
+            container.commands should have size 22
+            container.commands(14) shouldBe
                 s"/usr/lib/midolman/vpn-helper stop_service " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path"
+            container.commands(15) shouldBe
+                s"/usr/lib/midolman/vpn-helper cleanns " +
+                s"-n ${port.getInterfaceName}"
+            container.commands(16) shouldBe
+                s"/usr/lib/midolman/vpn-helper prepare"
             container.commands(17) shouldBe
                 s"/usr/lib/midolman/vpn-helper cleanns " +
                 s"-n ${port.getInterfaceName}"
             container.commands(18) shouldBe
-                s"/usr/lib/midolman/vpn-helper prepare"
-            container.commands(19) shouldBe
-                s"/usr/lib/midolman/vpn-helper cleanns " +
-                s"-n ${port.getInterfaceName}"
-            container.commands(21) shouldBe
                 s"/usr/lib/midolman/vpn-helper makens " +
                 s"-n ${port.getInterfaceName} " +
                 s"-g ${port.getPortAddress.asIPv4Address} " +
@@ -1571,20 +1563,20 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
                 s"-l ${port.getPortAddress.asIPv4Address} " +
                 s"-i $namespaceSubnet " +
                 s"-m ${port.getPortMac}"
-            container.commands(22) shouldBe
+            container.commands(19) shouldBe
                 s"/usr/lib/midolman/vpn-helper start_service " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path"
-            container.commands(23).startsWith(
+            container.commands(20).startsWith(
                 s"/usr/lib/midolman/vpn-helper init_conns " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path " +
                 s"-g ${port.getPortAddress.asIPv4Address} ") shouldBe true
-            container.commands(23).contains(
+            container.commands(20).contains(
                 s"-c ${IPSecConfig.vpnName(conn1.getId.asJava)}") shouldBe false
-            container.commands(23).contains(
+            container.commands(20).contains(
                 s"-c ${IPSecConfig.vpnName(conn2.getId.asJava)}") shouldBe true
-            container.commands(24) shouldBe
+            container.commands(21) shouldBe
                 "ip netns exec if-eth ipsec whack --status " +
                 s"--ctlbase $path/var/run/pluto"
 
@@ -1593,20 +1585,20 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             vpn1 = vt.store.get(classOf[VpnService], vpn1.getId).await()
 
             Then("The container is torn down and setup with both connection")
-            container.commands should have size 34
-            container.commands(25) shouldBe
+            container.commands should have size 30
+            container.commands(22) shouldBe
                 s"/usr/lib/midolman/vpn-helper stop_service " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path"
-            container.commands(26) shouldBe
+            container.commands(23) shouldBe
                 s"/usr/lib/midolman/vpn-helper cleanns " +
                 s"-n ${port.getInterfaceName}"
-            container.commands(27) shouldBe
+            container.commands(24) shouldBe
                 s"/usr/lib/midolman/vpn-helper prepare"
-            container.commands(28) shouldBe
+            container.commands(25) shouldBe
                 s"/usr/lib/midolman/vpn-helper cleanns " +
                 s"-n ${port.getInterfaceName}"
-            container.commands(30) shouldBe
+            container.commands(26) shouldBe
                 s"/usr/lib/midolman/vpn-helper makens " +
                 s"-n ${port.getInterfaceName} " +
                 s"-g ${port.getPortAddress.asIPv4Address} " +
@@ -1614,20 +1606,20 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
                 s"-l ${port.getPortAddress.asIPv4Address} " +
                 s"-i $namespaceSubnet " +
                 s"-m ${port.getPortMac}"
-            container.commands(31) shouldBe
+            container.commands(27) shouldBe
                 s"/usr/lib/midolman/vpn-helper start_service " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path"
-            container.commands(32).startsWith(
+            container.commands(28).startsWith(
                 s"/usr/lib/midolman/vpn-helper init_conns " +
                 s"-n ${port.getInterfaceName} " +
                 s"-p $path " +
                 s"-g ${port.getPortAddress.asIPv4Address} ") shouldBe true
-            container.commands(32).contains(
+            container.commands(28).contains(
                 s"-c ${IPSecConfig.vpnName(conn1.getId.asJava)}") shouldBe true
-            container.commands(32).contains(
+            container.commands(28).contains(
                 s"-c ${IPSecConfig.vpnName(conn2.getId.asJava)}") shouldBe true
-            container.commands(33) shouldBe
+            container.commands(29) shouldBe
                 "ip netns exec if-eth ipsec whack --status " +
                 s"--ctlbase $path/var/run/pluto"
 
@@ -1636,7 +1628,7 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             container.delete().await()
 
             Then("The container should call the cleanup commands")
-            container.commands should have size 36
+            container.commands should have size 32
 
             And("The container should unsubscribe from the observable")
             vpnSubscription.isUnsubscribed shouldBe true
@@ -1842,7 +1834,7 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             container.create(cp).await() should not be None
 
             Then("Calling the delete method while a command should fail")
-            container.throwOn = 8
+            container.throwOn = 7
             val vpnServiceSubscription = container.vpnServiceSubscription
             intercept[Exception] {
                 container.delete().await()
@@ -1854,7 +1846,7 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
 
             And("A second attempt that does not fail should succeed")
             container.delete().await()
-            container.commands should have size 10
+            container.commands should have size 9
 
             And("The container should unsubscribe from the observable")
             vpnServiceSubscription.isUnsubscribed shouldBe true
@@ -1910,7 +1902,7 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             container.delete().await()
 
             Then("The container should call the cleanup commands")
-            container.commands should have size 9
+            container.commands should have size 8
 
             And("The container should report deleted")
             obs.getOnNextEvents should have size 3
@@ -1960,9 +1952,9 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             container.create(cp).await() should not be None
 
             Then("The container should call the cleanup and setup commands")
-            container.commands should have size 7
+            container.commands should have size 6
             val regexp = "^ipsec-[\\w_]+$".r
-            val splits = container.commands(5).split(" ")
+            val splits = container.commands(4).split(" ")
             splits.size shouldBe 10
             regexp.pattern.matcher(splits(9)).matches shouldBe true
 
@@ -1971,7 +1963,7 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
             container.delete().await()
 
             Then("The container should call the cleanup commands")
-            container.commands should have size 9
+            container.commands should have size 8
 
             And("The container should unsubscribe from the observable")
             vpnServiceSubscription.isUnsubscribed shouldBe true


### PR DESCRIPTION
Fix for an issue where IPSEC service containers didn't start properly.

Midolman created a FIFO to read the log output of the pluto process started by an IPSEC container.  Reading the log data from the fifo is implemented by the Tailer class. A reading job is scheduled per IPSEC container, each job will open the fifo and then read for 500 ms, yield control to other jobs and reschedule itself. The job executor is single-threaded, so if one job blocks, no other job will read and new jobs won't even open the fifo.
If a pluto process never opens its log file, Midolman will block while trying to open the reader side of the fifo, indefinitely. New IPSEC containers will create their fifos, but will never open them because there is another one that's blocked. Thus the new pluto processes block while opening the writer side of their log fifos.

As a fix Midolman won't try to read the pluto log output anymore. The fifo is not used and pluto will write to a plain file instead.