### PR TITLE
os-4561 delete ipsec container on create fail

### DIFF
--- a/midolman/src/main/scala/org/midonet/midolman/containers/ContainerService.scala
+++ b/midolman/src/main/scala/org/midonet/midolman/containers/ContainerService.scala
@@ -550,7 +550,10 @@ class ContainerService(vt: VirtualTopology, hostId: UUID,
                 subscription.unsubscribe()
                 handleContainerError(instance, t, cp, errorStatus = true,
                                      Operation.Create)
-                deleteContainerForInstance(instance).andThen {
+
+                // Delete the container, but leave the container state ERROR
+                // which will be cleared later (deleteContainer)
+                deleteContainerForInstance(instance, false).andThen {
                     // On the service thread, try to delete the instance after
                     // the last container operation has completed.
                     case _ => deleteInstance(instance)
@@ -609,10 +612,12 @@ class ContainerService(vt: VirtualTopology, hostId: UUID,
                 }(ec)
             case instance: ContainerInstance =>
                 log warn s"There is no container $cp"
+                clearContainerStatus(instance, cp)
                 deleteInstance(instance)
                 Future.successful(null)
             case _ =>
-                log warn s"There is no container $cp"
+                log warn s"There is no container instance $cp"
+                clearContainerStatus(null, cp)
                 Future.successful(null)
         }
     }
@@ -620,7 +625,7 @@ class ContainerService(vt: VirtualTopology, hostId: UUID,
     /**
       * Deletes the container for the specified instance.
       */
-    private def deleteContainerForInstance(instance: ContainerInstance)
+    private def deleteContainerForInstance(instance: ContainerInstance, updateState: Boolean = true)
     : Future[Any] = {
         val handler = instance.handler.getOrElse {
             return Future.successful(())
@@ -628,8 +633,10 @@ class ContainerService(vt: VirtualTopology, hostId: UUID,
         instance.context.execute {
             tryOp(instance, handler.cp, errorStatus = false, Operation.Delete) {
                 // Set the container status to stopping.
-                setContainerStatus(instance, handler.cp, Code.STOPPING,
-                                   s"Container ${handler.cp} stopping")
+                if (updateState) {
+                    setContainerStatus(instance, handler.cp, Code.STOPPING,
+                                       s"Container ${handler.cp} stopping")
+                }
                 handler.handler.delete().andThen {
                     case _ => handler.subscription.unsubscribe()
                 }(instance.context.ec).andThen {
@@ -640,7 +647,7 @@ class ContainerService(vt: VirtualTopology, hostId: UUID,
                                              errorStatus = false,
                                              Operation.Delete)
                     case Success(_) =>
-                        clearContainerStatus(instance, handler.cp)
+                        if (updateState) clearContainerStatus(instance, handler.cp)
                 }(ec)
             }
         }

--- a/midolman/src/main/scala/org/midonet/midolman/containers/ContainerService.scala
+++ b/midolman/src/main/scala/org/midonet/midolman/containers/ContainerService.scala
@@ -550,7 +550,11 @@ class ContainerService(vt: VirtualTopology, hostId: UUID,
                 subscription.unsubscribe()
                 handleContainerError(instance, t, cp, errorStatus = true,
                                      Operation.Create)
-                deleteInstance(instance)
+                deleteContainerForInstance(instance).andThen {
+                    // On the service thread, try to delete the instance after
+                    // the last container operation has completed.
+                    case _ => deleteInstance(instance)
+                }(ec)
             case Success(_) =>
         }(ec)
     }

--- a/midolman/src/test/scala/org/midonet/midolman/containers/ContainerServiceTest.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/containers/ContainerServiceTest.scala
@@ -1285,8 +1285,8 @@ class ContainerServiceTest extends MidolmanSpec with TopologyBuilder
             val port2 = port.clearHostId()
             store.update(port2)
 
-            Then("The container status should be ERROR")
-            getContainerStatus(container.getId).get.getStatusCode shouldBe Code.ERROR
+            Then("The container status should not be set")
+            getContainerStatus(container.getId) shouldBe None
         }
 
         scenario("Status set when starting and stopping a bad delete container") {


### PR DESCRIPTION
Fix for an issue with container scheduling:
When creating a service container fails, the instance in ContainerService was deleted, but not the handler (e.g. IPSecContainer). The IPSEC container stayed subscribed to topology change events and kept on trying to set up the VPN service, even if the controller scheduled the container to a different host.

Now we delete the container, not only the instance, if creating the container failed. The container status is left as ERROR until the controller unbinds the container port / unschedules the container from the current host.