### PR TITLE
Fix for libreswan 3.29

### DIFF
--- a/midolman/build.gradle
+++ b/midolman/build.gradle
@@ -278,7 +278,7 @@ debian.doFirst {
         '-d', 'python',
         '-d', 'python-setproctitle',
         '-d', 'quagga (>= 0.99.23)',
-        '-d', 'libreswan (>= 3.14-1)',
+        '-d', 'libreswan (>= 1:3.29)',
         '-d', 'openjdk-8-jdk-headless | java8-runtime-headless | java8-runtime',
         '-d', 'iproute (>= 20111117-1ubuntu2.1)',
         '-d', 'linux-image-generic (>= 3.13.0) | linux-image-virtual (>= 3.13.0) | linux-image-generic-lts-trusty (>= 3.13.0) | linux-image-virtual-lts-trusty (>= 3.13.0) | openvswitch-datapath-dkms (>= 1.10)',

--- a/midolman/src/lib/midolman/service_containers/vpn/vpn-helper
+++ b/midolman/src/lib/midolman/service_containers/vpn/vpn-helper
@@ -135,7 +135,7 @@ init_conns() {
 
     set -e
     for ((i=0;i<$MAX_CONNS;i++)) do
-        ip netns exec $NAME ipsec addconn --ctlbase ${PLUTO_PATH}.ctl \
+        ip netns exec $NAME ipsec addconn --ctlbase ${PLUTO_PATH}/pluto.ctl \
                                           --defaultroutenexthop $GATEWAY_IP \
                                           --config $CONF_FILE \
                                           ${CONNS[$i]}

--- a/midolman/src/main/scala/org/midonet/containers/IPSecContainer.scala
+++ b/midolman/src/main/scala/org/midonet/containers/IPSecContainer.scala
@@ -212,7 +212,7 @@ case class IPSecConfig(script: String,
                    |    ikev2=${ikeVersionToConfig(c.getIkepolicy.getIkeVersion)}
                    |    ike=${ikeParamsToConfig(c.getIkepolicy)}
                    |    ikelifetime=${c.getIkepolicy.getLifetimeValue}s
-                   |    auth=${transformProtocolToConfig(c.getIpsecpolicy.getTransformProtocol)}
+                   |    phase2=${transformProtocolToConfig(c.getIpsecpolicy.getTransformProtocol)}
                    |    phase2alg=${ipsecParamsToConfig(c.getIpsecpolicy)}
                    |    type=${encapModeToConfig(c.getIpsecpolicy.getEncapsulationMode)}
                    |    lifetime=${c.getIpsecpolicy.getLifetimeValue}s

--- a/midolman/src/test/scala/org/midonet/containers/IPSecContainerTest.scala
+++ b/midolman/src/test/scala/org/midonet/containers/IPSecContainerTest.scala
@@ -177,7 +177,7 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
                    |    ikev2=never
                    |    ike=3des-sha1;modp1024
                    |    ikelifetime=${ike.getLifetimeValue}s
-                   |    auth=esp
+                   |    phase2=esp
                    |    phase2alg=3des-sha1;modp1024
                    |    type=tunnel
                    |    lifetime=${ipsec.getLifetimeValue}s
@@ -285,7 +285,7 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
                     |    ikev2=insist
                     |    ike=3des-sha1;modp1024
                     |    ikelifetime=${ike.getLifetimeValue}s
-                    |    auth=ah-esp
+                    |    phase2=ah-esp
                     |    phase2alg=3des-sha1;modp1024
                     |    type=transport
                     |    lifetime=${ipsec.getLifetimeValue}s
@@ -308,7 +308,7 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
                     |    ikev2=insist
                     |    ike=3des-sha1;modp1024
                     |    ikelifetime=${ike.getLifetimeValue}s
-                    |    auth=ah-esp
+                    |    phase2=ah-esp
                     |    phase2alg=3des-sha1;modp1024
                     |    type=transport
                     |    lifetime=${ipsec.getLifetimeValue}s
@@ -331,7 +331,7 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
                     |    ikev2=insist
                     |    ike=3des-sha1;modp1024
                     |    ikelifetime=${ike.getLifetimeValue}s
-                    |    auth=ah-esp
+                    |    phase2=ah-esp
                     |    phase2alg=3des-sha1;modp1024
                     |    type=transport
                     |    lifetime=${ipsec.getLifetimeValue}s
@@ -456,7 +456,7 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
                     |    ikev2=insist
                     |    ike=3des-sha1;modp1024
                     |    ikelifetime=${ike.getLifetimeValue}s
-                    |    auth=ah-esp
+                    |    phase2=ah-esp
                     |    phase2alg=3des-sha1;modp1024
                     |    type=transport
                     |    lifetime=${ipsec.getLifetimeValue}s
@@ -479,7 +479,7 @@ class IPSecContainerTest extends MidolmanSpec with Matchers with TopologyBuilder
                     |    ikev2=insist
                     |    ike=3des-sha1;modp1024
                     |    ikelifetime=${ike.getLifetimeValue}s
-                    |    auth=ah-esp
+                    |    phase2=ah-esp
                     |    phase2alg=3des-sha1;modp1024
                     |    type=transport
                     |    lifetime=${ipsec.getLifetimeValue}s

--- a/midolman/src/test/shell/service_containers/vpn/ipsec.conf
+++ b/midolman/src/test/shell/service_containers/vpn/ipsec.conf
@@ -23,7 +23,7 @@ conn test_conn
     ikev2=never
     ike=aes128-sha1;modp1536
     ikelifetime=3600s
-    auth=esp
+    phase2=esp
     phase2alg=aes128-sha1;modp1536
     type=tunnel
     lifetime=3600s


### PR DESCRIPTION
Adapt ipsec.conf and vpn-helper for new libreswan

    libreswan 3.29 expects the ipsec.conf key phase2 (formerly auth).
    And vpn-helper needs to set the correct pluto.ctl path in the ctlbase
    parameter of "ip netns exec $NAME ipsec addconn"