### PR TITLE
Add protocols to RuleProtocol

### DIFF
--- a/midonet-cluster/src/main/java/org/midonet/cluster/rest_api/neutron/models/RuleProtocol.java
+++ b/midonet-cluster/src/main/java/org/midonet/cluster/rest_api/neutron/models/RuleProtocol.java
@@ -36,7 +36,19 @@ public enum RuleProtocol {
     ICMP("icmp", org.midonet.packets.ICMP.PROTOCOL_NUMBER),
 
     @ZoomEnumValue("ICMPV6")
-    ICMPv6("icmpv6", org.midonet.packets.ICMPv6.PROTOCOL_NUMBER);
+    ICMPv6("icmpv6", org.midonet.packets.ICMPv6.PROTOCOL_NUMBER),
+
+    @ZoomEnumValue("AH")
+    AH("ah", (byte)51),
+
+    @ZoomEnumValue("VRRP")
+    VRRP("vrrp", (byte)112),
+
+    @ZoomEnumValue("ESP")
+    ESP("esp", (byte)50),
+
+    @ZoomEnumValue("IPIP")
+    IPIP("ipip", (byte)94);
 
     private final String value;
     private final byte number;
@@ -69,6 +81,9 @@ public enum RuleProtocol {
             if (s.equalsIgnoreCase(protocol.value)) {
                 return protocol;
             }
+        }
+        if (s.equalsIgnoreCase("ipv6-icmp")) {
+            return ICMPv6;
         }
         return null;
     }

--- a/midonet-cluster/src/main/java/org/midonet/cluster/rest_api/neutron/models/RuleProtocol.java
+++ b/midonet-cluster/src/main/java/org/midonet/cluster/rest_api/neutron/models/RuleProtocol.java
@@ -44,11 +44,17 @@ public enum RuleProtocol {
     @ZoomEnumValue("VRRP")
     VRRP("vrrp", (byte)112),
 
+    @ZoomEnumValue("GRE")
+    GRE("gre", (byte)47),
+
     @ZoomEnumValue("ESP")
     ESP("esp", (byte)50),
 
     @ZoomEnumValue("IPIP")
-    IPIP("ipip", (byte)94);
+    IPIP("ipip", (byte)4),
+
+    @ZoomEnumValue("IPIP94")
+    IPIP94("ipip94", (byte)94);
 
     private final String value;
     private final byte number;

--- a/nsdb/src/main/proto/commons.proto
+++ b/nsdb/src/main/proto/commons.proto
@@ -70,6 +70,10 @@ enum Protocol {
     UDP = 17;     // 0x11
     ICMP = 1;     // 0x1
     ICMPV6 = 58;  // 0x3a
+    ESP = 50;     // 0x32
+    AH = 51;      // 0x33
+    IPIP = 94;    // 0x5e
+    VRRP = 112;   // 0x70
 }
 
 enum LBStatus {

--- a/nsdb/src/main/proto/commons.proto
+++ b/nsdb/src/main/proto/commons.proto
@@ -70,9 +70,11 @@ enum Protocol {
     UDP = 17;     // 0x11
     ICMP = 1;     // 0x1
     ICMPV6 = 58;  // 0x3a
+    IPIP = 4;     // 0x4
+    GRE = 47;     // 0x2f
     ESP = 50;     // 0x32
     AH = 51;      // 0x33
-    IPIP = 94;    // 0x5e
+    IPIP94 = 94;  // 0x5e
     VRRP = 112;   // 0x70
 }
 


### PR DESCRIPTION
Add some rule protocols

Security group rules have an optional "protocol" field to let the
rule match only for a given IP protocol (e.g. "udp" or "17").
Internally Midonet implemented the allowed protocols in an enum
and if the user configures a protocol not covered by the enum, the
protocol condition is ignored. Without the protocol condition too
many packets may pass.
E.g. if UDP is restricted to a certain port by one rule and ESP is
allowed by another one (ingress, ethertype IPv4, protocol "esp")
the 2nd rule is saved by Midonet as (ingress, ethertype IPv4) which
will allow all UDP/TCP.

Added a few protocols to the enums:
AH, VRRP, ESP, GRE, IPIP (protocol 4), IPIP (protocol 94).
And accept the new name "ipv6-icmp" instead of "icmpv6" as well.
This fixes the rules for those protocols. For protocols other than
udp, tcp, icmp, ipv6-icmp, ah, vrrp, esp, gre, ipip the rules will still
be too weak.