### PR TITLE
VPNaaS: Support authorization algorithms sha256, sha384, sha512

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 project.ext {
-    midonetVersion = "5.4.6-se18"
+    midonetVersion = "5.4.6-se19"
     vendor = 'MidoNet'
     maintainer = "MidoNet user list <midonet-user@midonet.org>"
     url = "http://midonet.org"

--- a/midolman/src/main/scala/org/midonet/containers/IPSecContainer.scala
+++ b/midolman/src/main/scala/org/midonet/containers/IPSecContainer.scala
@@ -156,6 +156,9 @@ case class IPSecConfig(script: String,
     def ipsecAuthToConfig(authAlgorithm: IPSecAuthAlgorithm): String = {
         authAlgorithm match {
             case IPSecAuthAlgorithm.SHA1 => "sha1"
+            case IPSecAuthAlgorithm.SHA256 => "sha256"
+            case IPSecAuthAlgorithm.SHA384 => "sha384"
+            case IPSecAuthAlgorithm.SHA512 => "sha512"
         }
     }
 

--- a/midonet-cluster/src/main/java/org/midonet/cluster/rest_api/neutron/models/IPSecSiteConnection.java
+++ b/midonet-cluster/src/main/java/org/midonet/cluster/rest_api/neutron/models/IPSecSiteConnection.java
@@ -196,9 +196,9 @@ public class IPSecSiteConnection extends ZoomObject {
 
     @ZoomEnum(clazz = Neutron.IPSecSiteConnection.IPSecAuthAlgorithm.class)
     public enum IPSecAuthAlgorithm {
-        @ZoomEnumValue("SHA1")SHA1;
-        @ZoomEnumValue("SHA256")SHA256;
-        @ZoomEnumValue("SHA384")SHA384;
+        @ZoomEnumValue("SHA1")SHA1,
+        @ZoomEnumValue("SHA256")SHA256,
+        @ZoomEnumValue("SHA384")SHA384,
         @ZoomEnumValue("SHA512")SHA512;
 
         @JsonCreator

--- a/midonet-cluster/src/main/java/org/midonet/cluster/rest_api/neutron/models/IPSecSiteConnection.java
+++ b/midonet-cluster/src/main/java/org/midonet/cluster/rest_api/neutron/models/IPSecSiteConnection.java
@@ -197,6 +197,9 @@ public class IPSecSiteConnection extends ZoomObject {
     @ZoomEnum(clazz = Neutron.IPSecSiteConnection.IPSecAuthAlgorithm.class)
     public enum IPSecAuthAlgorithm {
         @ZoomEnumValue("SHA1")SHA1;
+        @ZoomEnumValue("SHA256")SHA256;
+        @ZoomEnumValue("SHA384")SHA384;
+        @ZoomEnumValue("SHA512")SHA512;
 
         @JsonCreator
         @SuppressWarnings("unused")

--- a/nsdb/src/main/proto/neutron.proto
+++ b/nsdb/src/main/proto/neutron.proto
@@ -501,6 +501,9 @@ message IPSecSiteConnection {
 
     enum IPSecAuthAlgorithm {
         SHA1 = 0;
+        SHA256 = 1;
+        SHA384 = 2;
+        SHA512 = 3;
     }
 
     enum IPSecEncryptionAlgorithm {


### PR DESCRIPTION
Add support for authorization algorithms sha256, sha384, sha512. Accept those choices in policy definitions from neutron and convert correctly to internal config and ipsec.conf