### PR TITLE
WIP: Allow AdoptOpenJDK 11 to run midonet

### DIFF
--- a/midolman/src/deb/init/prepare-java
+++ b/midolman/src/deb/init/prepare-java
@@ -17,6 +17,7 @@
 # The first existing directory is used for JAVA_HOME if needed.
 LIB_PATTERNS='{lib64,lib}'
 JVM_SEARCH_DIRS=$( eval echo \
+                 /usr/$LIB_PATTERNS/jvm/adoptopenjdk-11-hotspot-amd64 \
                  /usr/$LIB_PATTERNS/jvm/java-1.8.0-openjdk-amd64 \
                  /usr/$LIB_PATTERNS/jvm/java-8-openjdk-amd64 \
                  /usr/$LIB_PATTERNS/jvm/java-8-oracle \
@@ -29,7 +30,7 @@ JVM_SEARCH_DIRS=$( eval echo \
 check_for_java8() {
     [ "x" = "x$1" ] && return 1
     [ -x "$1" ] || return 1
-    $1 -version 2>&1 | grep -q 'version "1.8'
+    $1 -version 2>&1 | grep -q 'version "\(1.8\|11.0\)'
 }
 
 if [ -n "`which java`" ]; then

--- a/midonet-cluster/conf/midonet-cluster-env.sh
+++ b/midonet-cluster/conf/midonet-cluster-env.sh
@@ -19,6 +19,7 @@
 # The first existing directory is used for JAVA_HOME if needed.
 LIB_PATTERNS='{lib64,lib}'
 JVM_SEARCH_DIRS=$( bash -c "echo \
+                 /usr/$LIB_PATTERNS/jvm/adoptopenjdk-11-hotspot-amd64 \
                  /usr/$LIB_PATTERNS/jvm/java-1.8.0-openjdk-amd64 \
                  /usr/$LIB_PATTERNS/jvm/java-8-openjdk-amd64 \
                  /usr/$LIB_PATTERNS/jvm/java-8-oracle \
@@ -30,7 +31,7 @@ JVM_SEARCH_DIRS=$( bash -c "echo \
 check_for_java8() {
     [ "x" = "x$1" ] && return 1
     [ -x "$1" ] || return 1
-    $1 -version 2>&1 | grep -q 'version "1.8'
+    $1 -version 2>&1 | grep -q 'version "\(1.8\|11.0\)'
 }
 
 if [ -n "`which java`" ]; then

--- a/netlink/src/main/java/org/midonet/netlink/UnixChannel.java
+++ b/netlink/src/main/java/org/midonet/netlink/UnixChannel.java
@@ -315,7 +315,7 @@ public abstract class UnixChannel<Address> extends AbstractSelectableChannel
         IOUtil.configureBlocking(fd, block);
     }
 
-    public void translateAndSetInterestOps(int ops, SelectionKeyImpl sk) {
+    public int translateInterestOps(int ops) {
         int newOps = 0;
 
         if ((ops & SelectionKey.OP_ACCEPT) != 0)
@@ -327,6 +327,11 @@ public abstract class UnixChannel<Address> extends AbstractSelectableChannel
         if ((ops & SelectionKey.OP_CONNECT) != 0)
             newOps |= Net.POLLIN;
 
+        return newOps;
+    }
+
+    public void translateAndSetInterestOps(int ops, SelectionKeyImpl sk) {
+        int newOps = translateInterestOps(ops);
         sk.selector.putEventOps(sk, newOps);
     }
 


### PR DESCRIPTION
Added adoptopenjdk-11-hotspot to list of acceptable JVMs.
Fixed SelChImpl usage adapting to change between Java 8 and 11

Note that midolman-env.sh, minions-env.sh and/or midonet-cluster-env.sh
still need to be adjusted manually if Java 11 is used. E.g. some
options tuning the GC logging are not available anymore.